### PR TITLE
Utils/moco qc plots

### DIFF
--- a/pet_cli/image_operations_4d.py
+++ b/pet_cli/image_operations_4d.py
@@ -655,6 +655,11 @@ class ImageOps4d():
                                              verbose=preproc_props['Verbose'],
                                              half_life=preproc_props['HalfLife'],
                                              kwargs=preproc_props['MocoPars'])
+            motion = moco_outputs[2]
+            output_plot = os.path.join(self.output_directory,
+                                       f'{self.output_filename_prefix}_motion.png')
+            qc_plots.motion_plot(framewise_displacement=motion,
+                                 output_plot=output_plot)
             return moco_outputs
         elif method_name=='register_pet':
             output_file_name = f'{self.output_filename_prefix}_reg.nii.gz'

--- a/pet_cli/qc_plots.py
+++ b/pet_cli/qc_plots.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
+
 def motion_plot(framewise_displacement: np.ndarray,
                 output_plot: str=None):
     """
@@ -15,14 +16,18 @@ def motion_plot(framewise_displacement: np.ndarray,
     Args:
         framewise_displacement (np.ndarray): Total movement, or displacement,
             estimated between consecutive frames.
-        output_plot (str): File to which plot is saved. If `None`, write to
-            a temporary file. Default value `None`.
+        output_plot (str): File to which plot is saved. If `None`, do not write
+            plot to file. Default value `None`.
     
     Returns:
         movement_plot (sns.lineplot): Plot of total movement between frames.
     """
-    movement_dataframe = pd.DataFrame(columns=['Framewise Displacement (mm)'])
+    movement_dataframe = pd.DataFrame(columns=['Frame','Framewise Displacement (mm)'])
+    movement_dataframe['Frame'] = np.arange(len(framewise_displacement))
     movement_dataframe['Framewise Displacement (mm)'] = framewise_displacement
-    movement_plot = sns.lineplot(movement_dataframe,y='Framewise Displacement (mm)')
-    return movement_plot
+    movement_plot = sns.lineplot(data=movement_dataframe,x='Frame',y='Framewise Displacement (mm)')
 
+    if output_plot is None:
+        return movement_plot
+    movement_plot.get_figure().savefig(output_plot)
+    return movement_plot


### PR DESCRIPTION
Plots total computed movement against frame number when doing motion correction.

Implemented by writing a new module called `qc_plots` which has a single function that takes the motion array and plots it against frame number. image_operations_4d's class implementation runs this function whenever motion correction is ran in the preprocessing pipeline.

Additionally, small updates to a couple functions to fix minor bugs.