### PR TITLE
Get the half-life from a nifty meta-data file

### DIFF
--- a/petpal/utils/image_io.py
+++ b/petpal/utils/image_io.py
@@ -87,7 +87,7 @@ def load_metadata_for_nifty_with_same_filename(image_path) -> dict:
         Additionally, occurs if the metadata .json file cannot be found.
     """
     if not os.path.exists(image_path):
-        raise FileNotFoundError(f"Image file {image_path} not found")
+        raise FileNotFoundError(f"Image file {image_path} not found.")
 
     meta_path = _gen_meta_data_filepath_for_nifty(image_path)
 
@@ -165,6 +165,28 @@ def get_half_life_from_meta(meta_data_file_path: str):
         return half_life
     except KeyError:
         raise KeyError("RadionuclideHalfLife not found in meta-data file.")
+    
+def get_half_life_from_nifty(image_path:str):
+    """
+    Retrieves the radionuclide half-life from a nifti image file.
+
+    This function first checks if the provided nifti image file exists. It then derives
+    the corresponding metadata file path using :func:`_gen_meta_data_filepath_for_nifty`
+    and finally retrieves the half-life from the metadata using :func:`get_half_life_from_meta`.
+
+    Args:
+        image_path (str): Path to the nifti image file.
+
+    Returns:
+        float: The radionuclide half-life extracted from the metadata file.
+
+    Raises:
+        FileNotFoundError: If the nifti image file does not exist at the provided path.
+    """
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f"Image file {image_path} not found")
+    meta_path = _gen_meta_data_filepath_for_nifty(image_path)
+    return get_half_life_from_meta(meta_path)
 
 class ImageIO:
     """


### PR DESCRIPTION
Simple function to extract the `RadionuclideHalfLife` from a nifty-metadata file. We can probably extend it later to accept a list of possible keys for the HalfLife, or to infer the HalfLife from the radionuclide itself.
Additionally, make a private function to generate the meta-data path given a nifty path so that the regex is not repeated in different functions.