### PR TITLE
 feat: preproc_steps changes necessary for PiB pipeline

### DIFF
--- a/petpal/pipelines/preproc_steps.py
+++ b/petpal/pipelines/preproc_steps.py
@@ -248,7 +248,7 @@ class TACsFromSegmentationStep(FunctionBasedStep):
         self.out_tacs_prefix = f'sub-{sub_id}_ses-{ses_id}_desc-{step_name_in_camel_case}'
     
     @classmethod
-    def default_write_tacs_from_segmentation_rois(cls):
+    def default_write_tacs_from_segmentation_rois(cls, **overrides):
         """
         Provides a class method to create an instance with default parameters. All paths
         are set to empty strings, `time_keyword=FrameReferenceTime`, and `verbose=False`.
@@ -256,13 +256,16 @@ class TACsFromSegmentationStep(FunctionBasedStep):
         Returns:
             TACsFromSegmentationStep: A new instance with default parameters.
         """
-        return cls(input_image_path='',
-                   segmentation_image_path='',
-                   segmentation_label_map_path='',
-                   out_tacs_dir='',
-                   out_tacs_prefix='',
-                   time_keyword='FrameReferenceTime',
-                   verbose=False)
+
+        defaults = dict(input_image_path='', segmentation_image_path='', segmentation_label_map_path='',
+                        out_tacs_dir='', out_tacs_prefix='', time_keyword='FrameReferenceTime', verbose=False)
+        override_dict = defaults | overrides
+
+        try:
+            return cls(**override_dict)
+        except RuntimeError as err:
+            warnings.warn(f'Invalid override: {err}. Using default instance instead.', stacklevel=2)
+            return cls(**defaults)
     
 
 class ResampleBloodTACStep(FunctionBasedStep):

--- a/petpal/pipelines/preproc_steps.py
+++ b/petpal/pipelines/preproc_steps.py
@@ -645,14 +645,14 @@ class ImageToImageStep(FunctionBasedStep):
             return cls(**defaults)
 
     @classmethod
-    def default_register_pet_to_t1(cls, reference_image_path='', half_life='', verbose=False, **overrides):
+    def default_register_pet_to_t1(cls, reference_image_path='', half_life:float=None, verbose=False, **overrides):
         """
         Creates a default instance for registering PET to T1 image using :func:`register_pet<petpal.preproc.register.register_pet>`.
         All paths are empty-strings.
 
         Args:
             reference_image_path (str): Path to the reference image.
-            half_life (str): Half-life value, in seconds, for the radiotracer. Used to
+            half_life (float): Half-life value, in seconds, for the radiotracer. Used to
                 generate a weighted_series_sum image.
             verbose (bool): Whether to run in verbose mode.
             **overrides: Override default parameters.

--- a/petpal/pipelines/preproc_steps.py
+++ b/petpal/pipelines/preproc_steps.py
@@ -588,7 +588,7 @@ class ImageToImageStep(FunctionBasedStep):
         """
         defaults = dict(name='thresh_crop', function=SimpleAutoImageCropper, input_image_path='',
                         output_image_path='', )
-        override_dict = {**defaults, **overrides}
+        override_dict = defaults | overrides
         try:
             return cls(**override_dict)
         except RuntimeError as err:
@@ -612,7 +612,7 @@ class ImageToImageStep(FunctionBasedStep):
         defaults = dict(name='moco_frames_above_mean', function=motion_corr_frames_above_mean_value,
                         input_image_path='', output_image_path='', motion_target_option='mean_image', verbose=verbose,
                         half_life=None, )
-        override_dict = {**defaults, **overrides}
+        override_dict = defaults | overrides
         try:
             return cls(**override_dict)
         except RuntimeError as err:
@@ -637,7 +637,7 @@ class ImageToImageStep(FunctionBasedStep):
                         input_image_path='', output_image_path='',
                         motion_target_option='weighted_series_sum', w_size=60.0,
                         verbose=verbose)
-        override_dict = {**defaults, **overrides}
+        override_dict = defaults | overrides
         try:
             return cls(**override_dict)
         except RuntimeError as err:
@@ -663,8 +663,8 @@ class ImageToImageStep(FunctionBasedStep):
         """
         defaults = dict(name='register_pet_to_t1', function=register_pet, input_image_path='', output_image_path='',
                         reference_image_path=reference_image_path, motion_target_option='weighted_series_sum',
-                        verbose=verbose, half_life=half_life, )
-        override_dict = {**defaults, **overrides}
+                        verbose=verbose, half_life=half_life)
+        override_dict = defaults | overrides
         try:
             return cls(**override_dict)
         except RuntimeError as err:


### PR DESCRIPTION
Made the following changes: 

- Refactor: change all uses of `{**defaults, **overrides}` to `defaults | overrides` (new dict merge operator)
- Fix: change half_life type from str to float in the default register step
- Feat: allow overriding of arguments for in default_write_tacs_from_segmentation_rois()

Very small PR; just a few changes I had to make to get a PiB pipeline working. 